### PR TITLE
allow input for log group filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ No modules.
 | [aws_vpn_gateway_route_propagation.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpn_gateway_route_propagation) | resource |
 | [aws_iam_policy_document.flow_log_cloudwatch_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vpc_flow_log_cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_cloudwatch_log_subscription_filter.flow_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_subscription_filter) | resource |
 
 ## Inputs
 
@@ -716,6 +717,7 @@ No modules.
 | <a name="output_vpc_main_route_table_id"></a> [vpc\_main\_route\_table\_id](#output\_vpc\_main\_route\_table\_id) | The ID of the main route table associated with this VPC |
 | <a name="output_vpc_owner_id"></a> [vpc\_owner\_id](#output\_vpc\_owner\_id) | The ID of the AWS account that owns the VPC |
 | <a name="output_vpc_secondary_cidr_blocks"></a> [vpc\_secondary\_cidr\_blocks](#output\_vpc\_secondary\_cidr\_blocks) | List of secondary CIDR blocks of the VPC |
+| <a name="input_lg_filters"></a> [lg\_filters](#input\_lg\_filters) | Log group filters to create for Network Firewall logs | <pre>map(object({<br> naming_suffix = string<br> role_arn = string<br> filter_pattern = string<br> destination_arn = string<br> distribution = string<br>}))</pre> | `{}` | no |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/variables.tf
+++ b/variables.tf
@@ -182,6 +182,18 @@ variable "vpc_flow_log_tags" {
   default     = {}
 }
 
+variable "lg_filters" {
+  description = "Log group filters for Network Firewall"
+  type = map(object({
+    naming_suffix   = string
+    role_arn        = string
+    filter_pattern  = string
+    destination_arn = string
+    distribution    = string
+  }))
+  default = {}
+}
+
 ################################################################################
 # DHCP Options Set
 ################################################################################

--- a/vpc-flow-logs.tf
+++ b/vpc-flow-logs.tf
@@ -112,3 +112,13 @@ data "aws_iam_policy_document" "vpc_flow_log_cloudwatch" {
     resources = ["arn:aws:logs:*:*:log-group:${var.flow_log_cloudwatch_log_group_name_prefix}${local.flow_log_cloudwatch_log_group_name_suffix}:*"]
   }
 }
+
+resource "aws_cloudwatch_log_subscription_filter" "flow_log" {
+  for_each        = local.create_flow_log_cloudwatch_log_group ? var.lg_filters : {}
+  name            = "${one(aws_cloudwatch_log_group.flow_log[*]).name}-${each.value.naming_suffix}"
+  role_arn        = each.value.role_arn
+  log_group_name  = one(aws_cloudwatch_log_group.flow_log[*]).name
+  filter_pattern  = each.value.filter_pattern
+  destination_arn = each.value.destination_arn
+  distribution    = each.value.distribution
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Allow users to input log subscription filters for the flow logs. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The subscription filter should ideally reside alongside the flow logs. However, since this piece is missing, some have to abstract this logic out into another module which needs to be run whenever there's any updates to the log group resource. We always end up forgetting to apply this downstream resource in CX resulting in a lot of gaps in the logs streamed to other places. 

<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
Yes. It defaults to empty object, so no creation unless there's an input 
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
OGRE is using this. Tested with zero input. It is still able to work. 
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
