### PR TITLE
feat: Update aws_eip for aws v6 provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,13 +256,13 @@ Full contributing [guidelines are covered here](.github/contributing.md).
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.35 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.35 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -1235,7 +1235,7 @@ locals {
 resource "aws_eip" "nat" {
   count = local.create_vpc && var.enable_nat_gateway && !var.reuse_nat_ips ? local.nat_gateway_count : 0
 
-  vpc = true
+  domain = "vpc"
 
   tags = merge(
     {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.35"
+      version = ">= 5.0"
     }
   }
 }


### PR DESCRIPTION
Update `aws_eip` attribute to use `domain` (since aws v5) instead of `vpc` (aws v5 and below). Also update min aws provider version.

Currently, with aws v6 provider:
```
13:19:13.345 STDERR terraform: │ Error: Unsupported argument
13:19:13.345 STDERR terraform: │ 
13:19:13.345 STDERR terraform: │   on .terraform/modules/vpc/main.tf line 1238, in resource "aws_eip" "nat":
13:19:13.345 STDERR terraform: │ 1238:   vpc = true
13:19:13.345 STDERR terraform: │ 
13:19:13.345 STDERR terraform: │ An argument named "vpc" is not expected here.
13:19:13.345 STDERR terraform: ╵
```